### PR TITLE
socket path change due to qemu limitation : Path must be less than 10…

### DIFF
--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
         if !running?
           id_dir = @data_dir.join(@vm_id)
           image_path = id_dir.join("linked-box.img").to_s
-          unix_socket_path = id_dir.join("qemu_socket").to_s
+          unix_socket_path = [Dir.home, '/.vagrant.d/tmp/' , @vm_id,  '_qemu_socket'].join.to_s
           pid_file = id_dir.join("qemu.pid").to_s
 
           cmd = []
@@ -76,7 +76,7 @@ module VagrantPlugins
       def stop
         if running?
           id_dir = @data_dir.join(@vm_id)
-          unix_socket_path = id_dir.join("qemu_socket").to_s
+          unix_socket_path = [Dir.home, '/.vagrant.d/tmp/' , @vm_id,  '_qemu_socket'].join.to_s
           sent = false
           execute("nc", "-w", "5", "-U", unix_socket_path) do |type, data|
             case type


### PR DESCRIPTION
Hi, i've fix a socket path issue ( due to qemu  >104 chars limitation on socket)
https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars

I've moved socket to <user_home>/.vagrant.d/tmp.

Please, let me know if you have a dedicated process for PR