### PR TITLE
Allow passing arguments to QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This provider exposes a few provider-specific configuration options:
 * `net_device` - The network device, default: `virtio-net-device`
 * `image_path` - The path to qcow2 image for box-less VM, default is nil value
 * `qemu_dir` - The path to QEMU's install dir, default: `/opt/homebrew/share/qemu`
+* `extra_qemu_args` - The raw list of additional arguments to pass to QEMU. Use with extreme caution.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
             :smp => env[:machine].provider_config.smp,
             :memory => env[:machine].provider_config.memory,
             :net_device => env[:machine].provider_config.net_device,
+            :extra_qemu_args => env[:machine].provider_config.extra_qemu_args,
             :ports => forwarded_ports(env)
           }
 

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
       attr_accessor :net_device
       attr_accessor :image_path
       attr_accessor :qemu_dir
+      attr_accessor :extra_qemu_args
 
       def initialize
         @ssh_port = UNSET_VALUE
@@ -23,6 +24,7 @@ module VagrantPlugins
         @net_device = UNSET_VALUE
         @image_path = UNSET_VALUE
         @qemu_dir = UNSET_VALUE
+        @extra_qemu_args = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -44,6 +46,7 @@ module VagrantPlugins
         @net_device = "virtio-net-device" if @net_device == UNSET_VALUE
         @image_path = nil if @image_path == UNSET_VALUE
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
+        @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -85,6 +85,9 @@ module VagrantPlugins
           cmd += %W(-parallel null -monitor none -display none -vga none)
           cmd += %W(-daemonize)
 
+          # user-defined
+          cmd += options[:extra_qemu_args]
+
           execute(*cmd)
         end
       end


### PR DESCRIPTION
Sometimes it's useful, like to add a second network interface, or additional virtual disks, or anything that's not supported by the current limited set of options, really.