### PR TITLE
Allow passing extra netdev parameters to qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This provider exposes a few provider-specific configuration options:
 * `image_path` - The path to qcow2 image for box-less VM, default is nil value
 * `qemu_dir` - The path to QEMU's install dir, default: `/opt/homebrew/share/qemu`
 * `extra_qemu_args` - The raw list of additional arguments to pass to QEMU. Use with extreme caution. (see "Force Multicore" below as example)
+* `extra_netdev_args` - extra, comma-separated arguments to pass to the -netdev parameter. Use with caution. (see "Force Local IP" below as example)
 
 These can be set like typical provider-specific configuration:
 
@@ -174,6 +175,18 @@ Vagrant.configure("2") do |config|
     qe.net_device = "virtio-net-pci"
     qe.extra_qemu_args = %w(-accel tcg,thread=multi,tb-size=512)
     qe.qemu_dir = "/usr/local/share/qemu"
+  end
+end
+```
+
+7. Force Local IP
+
+```
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/bullseye64"
+
+  config.vm.provider "qemu" do |qe|
+    qe.extra_netdev_args = "net=192.168.51.0/24,dhcpstart=192.168.51.10"
   end
 end
 ```

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
             :memory => env[:machine].provider_config.memory,
             :net_device => env[:machine].provider_config.net_device,
             :extra_qemu_args => env[:machine].provider_config.extra_qemu_args,
+            :extra_netdev_args => env[:machine].provider_config.extra_netdev_args,
             :ports => forwarded_ports(env)
           }
 

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
       attr_accessor :image_path
       attr_accessor :qemu_dir
       attr_accessor :extra_qemu_args
+      attr_accessor :extra_netdev_args
 
       def initialize
         @ssh_port = UNSET_VALUE
@@ -25,6 +26,7 @@ module VagrantPlugins
         @image_path = UNSET_VALUE
         @qemu_dir = UNSET_VALUE
         @extra_qemu_args = UNSET_VALUE
+        @extra_netdev_args = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -47,6 +49,7 @@ module VagrantPlugins
         @image_path = nil if @image_path == UNSET_VALUE
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
         @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
+        @extra_netdev_args = nil if @extra_netdev_args == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -65,7 +65,11 @@ module VagrantPlugins
           options[:ports].each do |v|
             hostfwd += ",hostfwd=#{v}"
           end
-          cmd += %W(-netdev user,id=net0,#{hostfwd})
+          extra_netdev = ""
+          if !options[:extra_netdev_args].nil?
+            extra_netdev = ",#{options[:extra_netdev_args]}"
+          end
+          cmd += %W(-netdev user,id=net0,#{hostfwd}#{extra_netdev})
 
           # drive
           cmd += %W(-drive if=virtio,format=qcow2,file=#{image_path})


### PR DESCRIPTION
I have a special case where I need to adjust the network settings for the default network interface. I couldn't find a way to do it with extra_qemu_args so I added another configuration string that is concatenated to the default -netdev qemu parameter.
Modeled after #16 