### PR TITLE
Add missing :arch for driver.import(options)

### DIFF
--- a/lib/vagrant-qemu/action/import.rb
+++ b/lib/vagrant-qemu/action/import.rb
@@ -39,6 +39,7 @@ module VagrantPlugins
           options = {
             :image_path => image_path,
             :qemu_dir => qemu_dir,
+            :arch => env[:machine].provider_config.arch,
           }
 
           env[:ui].detail("Creating and registering the VM...")


### PR DESCRIPTION
Because this key was missing, `edk2-aarch64-code.fd` and `edk2-arm-vars.fd` would not get copied to `id_dir`.