### PR TITLE
Explicitly set firmware file permissions after copying from QEMU dir.

### DIFF
--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -148,7 +148,9 @@ module VagrantPlugins
         # Prepare firmware
         if options[:arch] == "aarch64"
           execute("cp", options[:qemu_dir].join("edk2-aarch64-code.fd").to_s, id_dir.join("edk2-aarch64-code.fd").to_s)
+          execute("chmod", "644", id_dir.join("edk2-aarch64-code.fd").to_s)
           execute("cp", options[:qemu_dir].join("edk2-arm-vars.fd").to_s, id_dir.join("edk2-arm-vars.fd").to_s)
+          execute("chmod", "644", id_dir.join("edk2-arm-vars.fd").to_s)
         end
 
         # Create image

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -148,7 +148,6 @@ module VagrantPlugins
         # Prepare firmware
         if options[:arch] == "aarch64"
           execute("cp", options[:qemu_dir].join("edk2-aarch64-code.fd").to_s, id_dir.join("edk2-aarch64-code.fd").to_s)
-          execute("chmod", "644", id_dir.join("edk2-aarch64-code.fd").to_s)
           execute("cp", options[:qemu_dir].join("edk2-arm-vars.fd").to_s, id_dir.join("edk2-arm-vars.fd").to_s)
           execute("chmod", "644", id_dir.join("edk2-arm-vars.fd").to_s)
         end


### PR DESCRIPTION
Hi. 

I recently switched from using Brew to manage QEMU, to Nix, and hit a permissions issue as a result.
When setting `qemu_dir` to the Nix QEMU directory instead of '/opt/homebrew/share/qemu', the VM failed to start.

```
Stderr: qemu-system-aarch64: Could not open '.../edk2-arm-vars.fd': Permission denied
```

In Brew, the firmware file permissions are '644', while with Nix they are '444'.