### PR TITLE
Add config 'firmware_format'

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This provider exposes a few provider-specific configuration options:
   * `control_port` - The port number used to control vm from vagrant, default is nil value. (nil means use unix socket)
   * `debug_port` - The port number used to export serial port of the vm for debug, default is nil value. (nil means use unix socket, see "Debug" below for details)
   * `no_daemonize` - Disable the "daemonize" mode of QEMU, default is false. (see "Windows host" below as example)
+  * `firmware_format` - The format of aarch64 firmware images (`edk2-aarch64-code.fd` and `edk2-arm-vars.fd`) loaded from `qemu_dir`, default: `raw`
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -25,7 +25,8 @@ module VagrantPlugins
             :ports => forwarded_ports(env),
             :control_port => env[:machine].provider_config.control_port,
             :debug_port => env[:machine].provider_config.debug_port,
-            :no_daemonize => env[:machine].provider_config.no_daemonize
+            :no_daemonize => env[:machine].provider_config.no_daemonize,
+            :firmware_format => env[:machine].provider_config.firmware_format
           }
 
           env[:ui].output(I18n.t("vagrant_qemu.starting"))

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       attr_accessor :control_port
       attr_accessor :debug_port
       attr_accessor :no_daemonize
+      attr_accessor :firmware_format
 
       def initialize
         @ssh_port = UNSET_VALUE
@@ -35,6 +36,7 @@ module VagrantPlugins
         @control_port = UNSET_VALUE
         @debug_port = UNSET_VALUE
         @no_daemonize = UNSET_VALUE
+        @firmware_format = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -62,6 +64,7 @@ module VagrantPlugins
         @control_port = nil if @control_port == UNSET_VALUE
         @debug_port = nil if @debug_port == UNSET_VALUE
         @no_daemonize = false if @no_daemonize == UNSET_VALUE
+        @firmware_format = "raw" if @firmware_format == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -93,8 +93,8 @@ module VagrantPlugins
           if options[:arch] == "aarch64"
             fm1_path = id_dir.join("edk2-aarch64-code.fd").to_s
             fm2_path = id_dir.join("edk2-arm-vars.fd").to_s
-            cmd += %W(-drive if=pflash,format=raw,file=#{fm1_path},readonly=on)
-            cmd += %W(-drive if=pflash,format=raw,file=#{fm2_path})
+            cmd += %W(-drive if=pflash,format=#{options[:firmware_format]},file=#{fm1_path},readonly=on)
+            cmd += %W(-drive if=pflash,format=#{options[:firmware_format]},file=#{fm2_path})
           end
 
           # control


### PR DESCRIPTION
Currently, the format of the aarch64 firmware images is hardcoded as `raw` -- this prevents the use of the qemu snapshot feature, even if the user has supplied `qcow2` formatted firmware images in their `qemu_dir`. This pull request adds a config option to specify the firmware image format, defaulting to `raw`.