### PR TITLE
Fix bug when using host_ip or guest_ip with forwarded_ports

### DIFF
--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -46,9 +46,9 @@ module VagrantPlugins
             next if options[:disabled]
 
             host_ip = ""
-            host_ip = "#{options[:host_ip]}:" if options[:host_ip]
+            host_ip = "#{options[:host_ip]}" if options[:host_ip]
             guest_ip = ""
-            guest_ip = "#{options[:guest_ip]}:" if options[:guest_ip]
+            guest_ip = "#{options[:guest_ip]}" if options[:guest_ip]
             result.push("#{options[:protocol]}:#{host_ip}:#{options[:host]}-#{guest_ip}:#{options[:guest]}")
           end
 


### PR DESCRIPTION
If you use `host_ip` or `guest_ip` when setting a `:forwarded_port`, you end up with a qemu command-line parsing error, as the code puts in extra, unnecessary colons. This patch simply removes these colons.

The patch is untested as I'm very lazy, I'm afraid.