### PR TITLE
fix the forwarded ports translation to qemu hostfwd entries

### DIFF
--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -45,11 +45,7 @@ module VagrantPlugins
             # Skip port if it is disabled
             next if options[:disabled]
 
-            host_ip = ""
-            host_ip = "#{options[:host_ip]}:" if options[:host_ip]
-            guest_ip = ""
-            guest_ip = "#{options[:guest_ip]}:" if options[:guest_ip]
-            result.push("#{options[:protocol]}:#{host_ip}:#{options[:host]}-#{guest_ip}:#{options[:guest]}")
+            result.push("#{options[:protocol]}:#{options[:host_ip]}:#{options[:host]}-#{options[:guest_ip]}:#{options[:guest]}")
           end
 
           result


### PR DESCRIPTION
This fixes https://github.com/ppggff/vagrant-qemu/issues/39.

This supersedes https://github.com/ppggff/vagrant-qemu/pull/47.

This now creates the entries as:

```
-netdev user,id=net0,hostfwd=tcp::50022-:22,hostfwd=tcp:127.0.0.1:55985-:5985,hostfwd=tcp:127.0.0.1:55986-:5986
```

Instead of:

```
-netdev user,id=net0,hostfwd=tcp::50022-:22,hostfwd=tcp:127.0.0.1::55985-:5985,hostfwd=tcp:127.0.0.1::55986-:5986
```