### PR TITLE
Issue #52: work-around for new Packer format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 * Allow more config options to be nil.
 * Let id start with "vq_".
 
-# 0.3.5 (2024-02-02)
+# 0.3.6 (2024-02-02)
 
 * Implemented quick work-around for issue #52.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,8 @@
 * Allow no cpu for riscv64.
 * Allow more config options to be nil.
 * Let id start with "vq_".
+
+# 0.3.5 (2024-02-02)
+
+* Implemented quick work-around for issue #52.
+

--- a/README.md
+++ b/README.md
@@ -332,6 +332,14 @@ config.vm.provider "qemu" do |qe|
 end
 ```
 
+### 5. VMs have no shared networking.
+
+Because this Vagrant plugin operates in user-mode, it is not possible to create a shared NAT network. Thus, a Vagrantfile which defines multiple VMs will result in multiple isolated VMs. Refer to issues [#40](https://github.com/ppggff/vagrant-qemu/issues/40), [#36](https://github.com/ppggff/vagrant-qemu/issues/36) and [#33](https://github.com/ppggff/vagrant-qemu/issues/33).
+
+### 6. Box creation fails with "Invalid box image path: ... libvirt/box.img"
+
+This is a known issue, refer to [issue #52](https://github.com/ppggff/vagrant-qemu/issues/52). A work-around is in progress, as is a real solution.  
+
 ## TODO
 
 * Support NFS shared folder

--- a/lib/vagrant-qemu/action/import.rb
+++ b/lib/vagrant-qemu/action/import.rb
@@ -16,7 +16,13 @@ module VagrantPlugins
           if env[:machine].provider_config.image_path
             image_path = Pathname.new(env[:machine].provider_config.image_path)
           elsif env[:machine].box
-            image_path = env[:machine].box.directory.join("box.img")
+            image_filename = "box.img"
+            image_path = env[:machine].box.directory.join(image_filename)
+            # Hack for issue 52, because Packer 1.1.0 changed the base image name.
+            if !image_path.file?
+              image_filename = "box_0.img"
+              image_path = env[:machine].box.directory.join(image_filename)
+            end
           end
 
           if !image_path || !image_path.file?

--- a/lib/vagrant-qemu/version.rb
+++ b/lib/vagrant-qemu/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module QEMU
-    VERSION = '0.3.5'
+    VERSION = '0.3.6'
   end
 end


### PR DESCRIPTION
Hi! 

I'm not saying this is a solid solution for issue #52 , but at least it's a work-around to get Vagrant imports to work again.

I have tested the changes using `generic/alma9` and `generic/alpine318`, while also testing with `perk/ubuntu-2204-arm64` which still uses the old Packer format. All three boxes can be imported without errors. 

```
tsluijter@tess-M2 Vagrant % vagrant init generic/alpine318

tsluijter@tess-M2 Vagrant % vagrant up     
Bringing machine 'default' up with 'qemu' provider...
==> default: Box 'generic/alpine318' could not be found. Attempting to find and install...
    default: Box Provider: libvirt
    default: Box Version: >= 0
==> default: Loading metadata for box 'generic/alpine318'
    default: URL: https://vagrantcloud.com/api/v2/vagrant/generic/alpine318
==> default: Adding box 'generic/alpine318' (v4.3.12) for provider: libvirt (arm64)
    default: Downloading: https://vagrantcloud.com/generic/boxes/alpine318/versions/4.3.12/providers/libvirt/arm64/vagrant.box
    default: Calculating and comparing box checksum...
==> default: Successfully added box 'generic/alpine318' (v4.3.12) for 'libvirt (arm64)'!
==> default: Checking if box 'generic/alpine318' version '4.3.12' is up to date...
==> default: Importing a QEMU instance
    default: Creating and registering the VM...
    default: Successfully imported VM
...
...
==> default: Machine booted and ready!

tsluijter@tess-M2 Vagrant % find ~/.vagrant.d/boxes/ -name "box*.img"
...
/Users/tsluijter/.vagrant.d/boxes//generic-VAGRANTSLASH-alpine318/4.3.12/arm64/libvirt/box_0.img
```