### PR TITLE
Update driver.rb stop method to wait for response after send shutdown (only control port)

### DIFF
--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -137,9 +137,13 @@ module VagrantPlugins
         if running?
           if !options[:control_port].nil?
             Socket.tcp("localhost", options[:control_port], connect_timeout: 5) do |sock|
+              # Wait for initial prompt
+              sock.gets("(qemu) ")
+              # Send system_powerdown
               sock.print "system_powerdown\n"
               sock.close_write
-              sock.read
+              # Wait for next prompt
+              sock.gets("(qemu) ")
             end
           else
             id_tmp_dir = @tmp_dir.join(@vm_id)


### PR DESCRIPTION
Added wait for prompt "(qemu) " text on QEMU Monitor console when stopping vm after send shutdown command.

Only control_port implementation (which need to be used in Windows) is changed. I don't have a Mac to test it so didn't touch Mac/Unix socket implementation. 
Same solution may work on Mac/Unix socket implementation. 

I used IO Class, gets Method with sep (Separator) Argument.

https://ruby-doc.org/3.2.2/IO.html#method-i-gets

I was having this error every time I stop (halt) machine:

```
==> default: Stopping the instance...
C:/Users/user/.vagrant.d/gems/3.1.3/gems/vagrant-qemu-0.3.6/lib/vagrant-qemu/driver.rb:142:in read': 
An existing connection was forcibly closed by the remote host. (Errno::ECONNRESET)
        from C:/Users/user/.vagrant.d/gems/3.1.3/gems/vagrant-qemu-0.3.6/lib/vagrant-qemu/driver.rb:142:in block in stop'
        from C:/Vagrant/embedded/mingw64/lib/ruby/3.1.0/socket.rb:659:in tcp'
        from C:/Users/user/.vagrant.d/gems/3.1.3/gems/vagrant-qemu-0.3.6/lib/vagrant-qemu/driver.rb:139:in stop'
        from C:/Users/user/.vagrant.d/gems/3.1.3/gems/vagrant-qemu-0.3.6/lib/vagrant-qemu/action/stop_instance.rb:16:in call'
```

I used "(qemu) " as  prompt text (with an ending space) because qemu monitor source code also use same text:

https://github.com/qemu/qemu/blob/master/monitor/hmp.c#L57
```
readline_start(mon->rs, "(qemu) ", 0, monitor_command_cb, NULL);
```

Tested with:
vagrant 2.3.8
vagrant-qemu 0.3.6
host windows 11
qemu MINGW64 mingw-w64-x86_64-qemu 9.0.0-1
vagrantfile centos-7 example in project readme