### PR TITLE
Add support for resizing disk on vm setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This provider exposes a few provider-specific configuration options:
   * `cpu` - The cpu model of VM, default: `cortex-a72`
   * `smp` - The smp setting (Simulate an SMP system with n CPUs) of VM, default: `2`
   * `memory` - The memory setting of VM, default: `4G`
+  * `disk_resize` - The target disk size (or adjustment of disk size), default is nil value. Examples: `40G`, `+20G`
 * debug/expert
   * `ssh_host` - The SSH IP used to access VM, default: `127.0.0.1`
   * `ssh_auto_correct` - Auto correct port collisions for ssh port, default: `false`

--- a/lib/vagrant-qemu/action/import.rb
+++ b/lib/vagrant-qemu/action/import.rb
@@ -75,6 +75,7 @@ module VagrantPlugins
             :image_path => image_path,
             :qemu_dir => qemu_dir,
             :arch => env[:machine].provider_config.arch,
+            :disk_resize => env[:machine].provider_config.disk_resize,
             :firmware_format => env[:machine].provider_config.firmware_format
           }
 

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :net_device
       attr_accessor :drive_interface
       attr_accessor :image_path
+      attr_accessor :disk_resize
       attr_accessor :qemu_dir
       attr_accessor :extra_qemu_args
       attr_accessor :extra_netdev_args
@@ -35,6 +36,7 @@ module VagrantPlugins
         @net_device = UNSET_VALUE
         @drive_interface = UNSET_VALUE
         @image_path = UNSET_VALUE
+        @disk_resize = UNSET_VALUE
         @qemu_dir = UNSET_VALUE
         @extra_qemu_args = UNSET_VALUE
         @extra_netdev_args = UNSET_VALUE
@@ -66,6 +68,7 @@ module VagrantPlugins
         @net_device = "virtio-net-device" if @net_device == UNSET_VALUE
         @drive_interface = "virtio" if @drive_interface == UNSET_VALUE
         @image_path = nil if @image_path == UNSET_VALUE
+        @disk_resize = nil if @disk_resize == UNSET_VALUE
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
         @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
         @extra_netdev_args = nil if @extra_netdev_args == UNSET_VALUE


### PR DESCRIPTION
The new config option `disk_resize` is passed to `qemu-img resize` command after the initial image is created. This allows to set or adjust the image size before starting the vm for the first time.

Resizing is limited to one image only. Error is signalled if multiple image files are provided by the box or by the config.