### PR TITLE
add support for `qemu_bin` to customize QEMU binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This provider exposes a few provider-specific configuration options:
   * `net_device` - The network device, default: `virtio-net-device`
   * `drive_interface` - The interface type for the main drive, default `virtio`
   * `image_path` - The path (or array of paths) to qcow2 image for box-less VM, default is nil value
+  * `qemu_bin` - Path to an alternative QEMU binary, default: autodetected
   * `qemu_dir` - The path to QEMU's install dir, default: `/opt/homebrew/share/qemu`
   * `extra_qemu_args` - The raw list of additional arguments to pass to QEMU. Use with extreme caution. (see "Force Multicore" below as example)
   * `extra_netdev_args` - extra, comma-separated arguments to pass to the -netdev parameter. Use with caution. (see "Force Local IP" below as example)

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
             :memory => env[:machine].provider_config.memory,
             :net_device => env[:machine].provider_config.net_device,
             :drive_interface => env[:machine].provider_config.drive_interface,
+            :qemu_bin => env[:machine].provider_config.qemu_bin,
             :extra_qemu_args => env[:machine].provider_config.extra_qemu_args,
             :extra_netdev_args => env[:machine].provider_config.extra_netdev_args,
             :ports => fwPorts,

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :net_device
       attr_accessor :drive_interface
       attr_accessor :image_path
+      attr_accessor :qemu_bin
       attr_accessor :qemu_dir
       attr_accessor :extra_qemu_args
       attr_accessor :extra_netdev_args
@@ -35,6 +36,7 @@ module VagrantPlugins
         @net_device = UNSET_VALUE
         @drive_interface = UNSET_VALUE
         @image_path = UNSET_VALUE
+        @qemu_bin = UNSET_VALUE
         @qemu_dir = UNSET_VALUE
         @extra_qemu_args = UNSET_VALUE
         @extra_netdev_args = UNSET_VALUE
@@ -66,6 +68,7 @@ module VagrantPlugins
         @net_device = "virtio-net-device" if @net_device == UNSET_VALUE
         @drive_interface = "virtio" if @drive_interface == UNSET_VALUE
         @image_path = nil if @image_path == UNSET_VALUE
+        @qemu_bin = nil if @qemu_bin == UNSET_VALUE
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
         @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
         @extra_netdev_args = nil if @extra_netdev_args == UNSET_VALUE

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -78,7 +78,15 @@ module VagrantPlugins
           end
 
           cmd = []
-          cmd += %W(qemu-system-#{options[:arch]})
+          if options[:qemu_bin].nil?
+            cmd += %W(qemu-system-#{options[:arch]})
+          else
+            if options[:qemu_bin].kind_of?(Array)
+              cmd += options[:qemu_bin]
+            else
+              cmd += %W(#{options[:qemu_bin]})
+            end
+          end
 
           # basic
           cmd += %W(-machine #{options[:machine]}) if !options[:machine].nil?

--- a/lib/vagrant-qemu/version.rb
+++ b/lib/vagrant-qemu/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module QEMU
-    VERSION = '0.3.9'
+    VERSION = '0.3.10'
   end
 end


### PR DESCRIPTION
This allows launching QEMU, for example, with [socket_vmnet](https://github.com/lima-vm/socket_vmnet) for rootless-vmnet support.