### PR TITLE
Cloud init support, support for extra `-drive` args, and `qemu-img` customization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This provider exposes a few provider-specific configuration options:
   * `qemu_dir` - The path to QEMU's install dir, default: `/opt/homebrew/share/qemu`
   * `extra_qemu_args` - The raw list of additional arguments to pass to QEMU. Use with extreme caution. (see "Force Multicore" below as example)
   * `extra_netdev_args` - extra, comma-separated arguments to pass to the -netdev parameter. Use with caution. (see "Force Local IP" below as example)
+  * `extra_drive_args` - Add optional extra arguments to each drive attached, default: `[]`
   * `control_port` - The port number used to control vm from vagrant, default is nil value. (nil means use unix socket)
   * `debug_port` - The port number used to export serial port of the vm for debug, default is nil value. (nil means use unix socket, see "Debug" below for details)
   * `no_daemonize` - Disable the "daemonize" mode of QEMU, default is false. (see "Windows host" below as example)

--- a/README.md
+++ b/README.md
@@ -276,6 +276,32 @@ Thanks example from @Leandros.
 
 See [pr#73](https://github.com/ppggff/vagrant-qemu/pull/73) for details.
 
+11. Improved VM I/O performance
+
+When creating the disks that are attached, each disk is an id assign in order
+they appear in the `Vagrantfile`. The primary disk has the `id` of `disk0`.
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ... other stuff
+
+  config.vm.provider "qemu" do |qe|
+    # Use a `none` drive interface.
+    qe.drive_interface = "none"
+    qe.extra_drive_args = "cache=none,aio=threads"
+
+    # To improve I/O performance, create a separate I/O thread.
+    # We refer to the primary disk as `disk0`.
+    qe.extra_qemu_args = %w(
+        -object iothread,id=io1
+        -device virtio-blk-pci,drive=disk0,iothread=io1
+    )
+  end
+end
+```
+
+See the [QEMU Documentation](https://www.qemu.org/docs/master/devel/multiple-iothreads.html) and [heiko-sieger.info/tuning-vm-disk-performance/](https://www.heiko-sieger.info/tuning-vm-disk-performance/) for more details.
+
 ## Debug
 
 Serial port is exported to unix socket: `<user_home>/.vagrant.d/tmp/vagrant-qemu/<id>/qemu_socket_serial`, or `debug_port`.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This provider exposes a few provider-specific configuration options:
   * `no_daemonize` - Disable the "daemonize" mode of QEMU, default is false. (see "Windows host" below as example)
   * `firmware_format` - The format of aarch64 firmware images (`edk2-aarch64-code.fd` and `edk2-arm-vars.fd`) loaded from `qemu_dir`, default: `raw`
   * `other_default` - The other default arguments used by this plugin, default: `%W(-parallel null -monitor none -display none -vga none)`
+  * `extra_image_opts` - Options passed via `-o` to `qemu-img` when the base qcow2 images are created, default: `[]`
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This provider exposes a few provider-specific configuration options:
   * `cpu` - The cpu model of VM, default: `cortex-a72`
   * `smp` - The smp setting (Simulate an SMP system with n CPUs) of VM, default: `2`
   * `memory` - The memory setting of VM, default: `4G`
+  * `disk_resize` - The target disk size (or adjustment of disk size), default is nil value. Examples: `40G`, `+20G`
 * debug/expert
   * `ssh_host` - The SSH IP used to access VM, default: `127.0.0.1`
   * `ssh_auto_correct` - Auto correct port collisions for ssh port, default: `false`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This provider exposes a few provider-specific configuration options:
   * `cpu` - The cpu model of VM, default: `cortex-a72`
   * `smp` - The smp setting (Simulate an SMP system with n CPUs) of VM, default: `2`
   * `memory` - The memory setting of VM, default: `4G`
-  * `disk_resize` - The target disk size of the primary disks, requires resizing of filesystem inside of VM, default: `nil`.
+  * `disk_resize` - The target disk size of the primary disk, requires resizing of filesystem inside of VM, default: `nil`.
 * debug/expert
   * `ssh_host` - The SSH IP used to access VM, default: `127.0.0.1`
   * `ssh_auto_correct` - Auto correct port collisions for ssh port, default: `false`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This provider exposes a few provider-specific configuration options:
   * `cpu` - The cpu model of VM, default: `cortex-a72`
   * `smp` - The smp setting (Simulate an SMP system with n CPUs) of VM, default: `2`
   * `memory` - The memory setting of VM, default: `4G`
-  * `disk_resize` - The target disk size (or adjustment of disk size), default is nil value. Examples: `40G`, `+20G`
+  * `disk_resize` - The target disk size of the primary disks, requires resizing of filesystem inside of VM, default: `nil`.
 * debug/expert
   * `ssh_host` - The SSH IP used to access VM, default: `127.0.0.1`
   * `ssh_auto_correct` - Auto correct port collisions for ssh port, default: `false`

--- a/lib/vagrant-qemu.rb
+++ b/lib/vagrant-qemu.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
   module QEMU
     lib_path = Pathname.new(File.expand_path("../vagrant-qemu", __FILE__))
     autoload :Action, lib_path.join("action")
+    autoload :Cap, lib_path.join("cap")
     autoload :Errors, lib_path.join("errors")
 
     # This returns the path to the source of this plugin.

--- a/lib/vagrant-qemu/action.rb
+++ b/lib/vagrant-qemu/action.rb
@@ -115,6 +115,9 @@ module VagrantPlugins
               next
             end
 
+            b1.use CloudInitSetup
+            b1.use CleanupDisks
+            b1.use Disk
             b1.use Provision
             b1.use EnvSet, port_collision_repair: true
             b1.use PrepareForwardedPortCollisionParams

--- a/lib/vagrant-qemu/action/import.rb
+++ b/lib/vagrant-qemu/action/import.rb
@@ -75,7 +75,8 @@ module VagrantPlugins
             :image_path => image_path,
             :qemu_dir => qemu_dir,
             :arch => env[:machine].provider_config.arch,
-            :firmware_format => env[:machine].provider_config.firmware_format
+            :firmware_format => env[:machine].provider_config.firmware_format,
+            :extra_image_opts => env[:machine].provider_config.extra_image_opts,
           }
 
           env[:ui].detail("Creating and registering the VM...")

--- a/lib/vagrant-qemu/action/import.rb
+++ b/lib/vagrant-qemu/action/import.rb
@@ -77,6 +77,7 @@ module VagrantPlugins
             :arch => env[:machine].provider_config.arch,
             :firmware_format => env[:machine].provider_config.firmware_format,
             :extra_image_opts => env[:machine].provider_config.extra_image_opts,
+            :disk_resize => env[:machine].provider_config.disk_resize,
           }
 
           env[:ui].detail("Creating and registering the VM...")

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -25,6 +25,7 @@ module VagrantPlugins
             :qemu_bin => env[:machine].provider_config.qemu_bin,
             :extra_qemu_args => env[:machine].provider_config.extra_qemu_args,
             :extra_netdev_args => env[:machine].provider_config.extra_netdev_args,
+            :extra_drive_args => env[:machine].provider_config.extra_drive_args,
             :ports => fwPorts,
             :control_port => env[:machine].provider_config.control_port,
             :debug_port => env[:machine].provider_config.debug_port,

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -31,7 +31,8 @@ module VagrantPlugins
             :debug_port => env[:machine].provider_config.debug_port,
             :no_daemonize => env[:machine].provider_config.no_daemonize,
             :firmware_format => env[:machine].provider_config.firmware_format,
-            :other_default => env[:machine].provider_config.other_default
+            :other_default => env[:machine].provider_config.other_default,
+            :extra_image_opts => env[:machine].provider_config.extra_image_opts,
           }
 
           env[:ui].output(I18n.t("vagrant_qemu.starting"))

--- a/lib/vagrant-qemu/cap.rb
+++ b/lib/vagrant-qemu/cap.rb
@@ -1,0 +1,8 @@
+
+module VagrantPlugins
+  module QEMU
+    module Cap
+      autoload :Disk, "vagrant-qemu/cap/disk"
+    end
+  end
+end

--- a/lib/vagrant-qemu/cap/disk.rb
+++ b/lib/vagrant-qemu/cap/disk.rb
@@ -1,0 +1,104 @@
+require "log4r"
+
+module VagrantPlugins
+  module QEMU
+    module Cap
+      module Disk
+        @@logger = Log4r::Logger.new("vagrant_qemu::cap::disk")
+
+        DEFAULT_DISK_EXT_LIST = ["qcow2", "iso"].map(&:freeze).freeze
+        DEFAULT_DISK_EXT = "qcow2".freeze
+
+        # @param [Vagrant::Machine] machine
+        # @return [String]
+        def self.set_default_disk_ext(machine)
+          DEFAULT_DISK_EXT
+        end
+
+        # @param [Vagrant::Machine] machine
+        # @return [Array]
+        def self.default_disk_exts(machine)
+          DEFAULT_DISK_EXT_LIST
+        end
+
+        # @param [Vagrant::Machine] machine
+        # @param [String] disk_ext
+        # @return [Bool]
+        def self.validate_disk_ext(machine, disk_ext)
+          DEFAULT_DISK_EXT_LIST.include?(disk_ext)
+        end
+
+        # @param [Vagrant::Machine] machine
+        # @param [VagrantPlugins::Kernel_V2::VagrantConfigDisk] defined_disks
+        # @return [Hash] configured_disks - A hash of all the current configured disks
+        def self.configure_disks(machine, defined_disks)
+          return {} if defined_disks.empty?
+
+          configured_disks = {disk: [], floppy: [], dvd: []}
+          defined_disks.each do |disk|
+            @@logger.info("Disk: #{disk.to_yaml}")
+            case disk.type
+            when :disk
+              disk_data = setup_disk(machine, disk)
+              if !disk_data.empty?
+                configured_disks[:disk] << disk_data
+                machine.provider.driver.attach_disk(disk_data)
+              end
+            when :floppy
+              machine.ui.info(I18n.t("vagrant_qemu.errors.floppy_unsupported"))
+            when :dvd
+              disk_data = setup_dvd(machine, disk)
+              if !disk_data.empty?
+                configured_disks[:dvd] << disk_data
+                machine.provider.driver.attach_dvd(disk_data)
+              end
+            else
+              @@logger.info("unsupported disk type: #{disk.type}")
+            end
+          end
+
+          configured_disks
+        end
+
+        # @param [Vagrant::Machine] machine
+        # @param [VagrantPlugins::Kernel_V2::VagrantConfigDisk] defined_disks
+        # @param [Hash] disk_meta - A hash of all the previously defined disks
+        #                           from the last configure_disk action
+        # @return [nil]
+        def self.cleanup_disks(machine, defined_disks, disk_meta)
+          return if disk_meta.values.flatten.empty?
+        end
+
+        protected
+
+        # Sets up all disk configs of type `:disk`
+        #
+        # @param [Vagrant::Machine] machine - the current machine
+        # @param [Config::Disk] disk - the current disk to configure
+        # @return [Hash] - disk_metadata
+        def self.setup_disk(machine, disk)
+          disk_dir = machine.provider.driver.disk_dir
+          disk_path = disk_dir.join("#{disk.name}.#{disk.disk_ext}")
+          args = ["create", "-f", "qcow2"]
+
+          disk_provider_config = disk.provider_config[:qemu] if disk.provider_config
+          args.push(disk_path.to_s)
+          args.push("#{disk.size}")
+          machine.provider.driver.execute("qemu-img", *args)
+
+          {UUID: disk.id, Name: disk.name, Path: disk_path.to_s, primary: !!disk.primary}
+        end
+
+        # Sets up all disk configs of type `:dvd`
+        #
+        # @param [Vagrant::Machine] machine - the current machine
+        # @param [Config::Disk] disk - the current disk to configure
+        # @return [Hash] - disk_metadata
+        def self.setup_dvd(machine, disk)
+          {UUID: disk.id, Name: disk.name, Path: disk.file, primary: !!disk.primary}
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -24,6 +24,7 @@ module VagrantPlugins
       attr_accessor :no_daemonize
       attr_accessor :firmware_format
       attr_accessor :other_default
+      attr_accessor :extra_image_opts
 
       def initialize
         @ssh_host = UNSET_VALUE
@@ -47,6 +48,7 @@ module VagrantPlugins
         @no_daemonize = UNSET_VALUE
         @firmware_format = UNSET_VALUE
         @other_default = UNSET_VALUE
+        @extra_image_opts = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -80,6 +82,7 @@ module VagrantPlugins
         @no_daemonize = false if @no_daemonize == UNSET_VALUE
         @firmware_format = "raw" if @firmware_format == UNSET_VALUE
         @other_default = %W(-parallel null -monitor none -display none -vga none) if @other_default == UNSET_VALUE
+        @extra_image_opts = nil if @extra_image_opts == UNSET_VALUE
 
         # TODO better error msg
         @ssh_port = Integer(@ssh_port)

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -16,6 +16,7 @@ module VagrantPlugins
       attr_accessor :image_path
       attr_accessor :qemu_bin
       attr_accessor :qemu_dir
+      attr_accessor :disk_resize
       attr_accessor :extra_qemu_args
       attr_accessor :extra_netdev_args
       attr_accessor :extra_drive_args
@@ -40,6 +41,7 @@ module VagrantPlugins
         @image_path = UNSET_VALUE
         @qemu_bin = UNSET_VALUE
         @qemu_dir = UNSET_VALUE
+        @disk_resize = UNSET_VALUE
         @extra_qemu_args = UNSET_VALUE
         @extra_netdev_args = UNSET_VALUE
         @extra_drive_args = UNSET_VALUE
@@ -74,6 +76,7 @@ module VagrantPlugins
         @image_path = nil if @image_path == UNSET_VALUE
         @qemu_bin = nil if @qemu_bin == UNSET_VALUE
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
+        @disk_resize = nil if @disk_resize == UNSET_VALUE
         @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
         @extra_netdev_args = nil if @extra_netdev_args == UNSET_VALUE
         @extra_drive_args = nil if @extra_drive_args == UNSET_VALUE

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       attr_accessor :qemu_dir
       attr_accessor :extra_qemu_args
       attr_accessor :extra_netdev_args
+      attr_accessor :extra_drive_args
       attr_accessor :control_port
       attr_accessor :debug_port
       attr_accessor :no_daemonize
@@ -40,6 +41,7 @@ module VagrantPlugins
         @qemu_dir = UNSET_VALUE
         @extra_qemu_args = UNSET_VALUE
         @extra_netdev_args = UNSET_VALUE
+        @extra_drive_args = UNSET_VALUE
         @control_port = UNSET_VALUE
         @debug_port = UNSET_VALUE
         @no_daemonize = UNSET_VALUE
@@ -72,6 +74,7 @@ module VagrantPlugins
         @qemu_dir = "/opt/homebrew/share/qemu" if @qemu_dir == UNSET_VALUE
         @extra_qemu_args = [] if @extra_qemu_args == UNSET_VALUE
         @extra_netdev_args = nil if @extra_netdev_args == UNSET_VALUE
+        @extra_drive_args = nil if @extra_drive_args == UNSET_VALUE
         @control_port = nil if @control_port == UNSET_VALUE
         @debug_port = nil if @debug_port == UNSET_VALUE
         @no_daemonize = false if @no_daemonize == UNSET_VALUE

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -204,7 +204,15 @@ module VagrantPlugins
         # Create image
         options[:image_path].each_with_index do |img, i|
           suffix_index = i > 0 ? "-#{i}" : ''
-          execute("qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", img.to_s, id_dir.join("linked-box#{suffix_index}.img").to_s)
+          args = ["create", "-f", "qcow2", "-F", "qcow2", "-b", img.to_s]
+          if !options[:extra_image_opts].nil?
+            options[:extra_image_opts].each do |opt|
+              args.push("-o")
+              args.push(opt)
+            end
+          end
+          args.push(id_dir.join("linked-box#{suffix_index}.img").to_s)
+          execute("qemu-img",  *args)
         end
 
         server = {

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -233,8 +233,10 @@ module VagrantPlugins
 
           args.push(linked_image)
 
-          if !options[:disk_resize].nil?
-            args.push(options[:disk_resize])
+          if i == 0
+            if !options[:disk_resize].nil?
+              args.push(options[:disk_resize])
+            end
           end
 
           execute("qemu-img",  *args)

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -112,9 +112,16 @@ module VagrantPlugins
           end
 
           # drive
+          diskid = 0
+          extra_drive_args = ""
+          if !options[:extra_drive_args].nil?
+            extra_drive_args = ",#{options[:extra_drive_args]}"
+          end
+
           if !options[:drive_interface].nil?
             image_path.each do |img|
-              cmd += %W(-drive if=#{options[:drive_interface]},format=qcow2,file=#{img})
+              cmd += %W(-drive if=#{options[:drive_interface]},id=disk#{diskid},format=qcow2,file=#{img}#{extra_drive_args})
+              diskid += 1
             end
           end
           if options[:arch] == "aarch64" && !options[:firmware_format].nil?

--- a/lib/vagrant-qemu/plugin.rb
+++ b/lib/vagrant-qemu/plugin.rb
@@ -24,6 +24,31 @@ module VagrantPlugins
         Config
       end
 
+      provider_capability(:qemu, :set_default_disk_ext) do
+        require File.expand_path("../cap/disk", __FILE__)
+        Cap::Disk
+      end
+
+      provider_capability(:qemu, :default_disk_exts) do
+        require File.expand_path("../cap/disk", __FILE__)
+        Cap::Disk
+      end
+
+      provider_capability(:qemu, :configure_disks) do
+        require File.expand_path("../cap/disk", __FILE__)
+        Cap::Disk
+      end
+
+      provider_capability(:qemu, :cleanup_disks) do
+        require File.expand_path("../cap/disk", __FILE__)
+        Cap::Disk
+      end
+
+      provider_capability(:qemu, :validate_disk_ext) do
+        require File.expand_path("../cap/disk", __FILE__)
+        Cap::Disk
+      end
+
       provider(:qemu, box_format: "libvirt", box_optional: true, parallel: true) do
         # Setup logging and i18n
         setup_logging

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -58,3 +58,5 @@ en:
         Invalid config.
 
         Error: %{err}
+      floppy_unsupported: |-
+        Floppy disks not supported


### PR DESCRIPTION
Vagrantfile used for testing:

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

# Requires: Vagrant QEMU Provider
# Install with: `vagrant plugin install vagrant-qemu`
# Documentation: https://github.com/ppggff/vagrant-qemu

# Use config version "2"!
Vagrant.configure("2") do |config|
  # For a complete reference, please see the online documentation at
  # https://docs.vagrantup.com.

  # Custom variables.
  current_dir = Dir.getwd

  # Default QEMU options.
  config.vm.provider "qemu" do |qe, override|
    override.ssh.username = "vagrant-user"
    override.ssh.private_key_path = "#{current_dir}/sshkey.pem"

    qe.smp = 4
    qe.memory = "4G"
    qe.cpu = "host"

    qe.drive_interface = "none"
    qe.extra_drive_args = "cache=none,aio=threads"
    qe.extra_image_opts = ["cluster_size=2M"]
    qe.other_default = [
      "-parallel", "null", "-monitor", "none", "-display", "none", "-vga", "none",
      # Improve I/O Performance of primary disk (`disk0`)
      "-object", "iothread,id=io1",
      "-device", "virtio-blk-pci,drive=disk0,iothread=io1",
      # Improve I/O Performance of secondary disk (`disk1`)
      "-object", "iothread,id=io2",
      "-device", "virtio-blk-pci,drive=disk1,iothread=io2",
    ]
  end

  # VM 1
  config.vm.define "vm1" do |c|
    c.vm.provider "qemu" do |qe|
      qe.ssh_port = 20022
      qe.image_path = "#{current_dir}/base-images/debian-12-aarch64.qcow2"
    end
    c.vm.synced_folder ".", "/vagrant", disabled: true
    c.vm.cloud_init :user_data do |cloud_init|
      cloud_init.content_type = "text/cloud-config"
      cloud_init.inline = <<-EOF
        hostname: vm1
      EOF
    end
    c.vm.disk :disk, name: "backup", size: "10GB"
  end

  config.vm.box_check_update = false
  config.vm.synced_folder ".", "/vagrant", disabled: true

  config.vm.cloud_init :user_data do |cloud_init|
    cloud_init.content_type = "text/cloud-config"
    cloud_init.path = "#{current_dir}/cloud-init/user-data"
  end
end
```

## Testing

SSH into VM and execute `lsblk` to see attached drive.

Observe the `hostname` is changed to `vm1`, as set by the `cloud-init` user-data script.