### PR TITLE
Feature: Add NUMA node pinning for QEMU process

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Others:
 * Basic suport to forwarded ports, see [vagrant doc](https://www.vagrantup.com/docs/networking/forwarded_ports) for details
 * Support Cloud-init, see [vagrant doc](https://developer.hashicorp.com/vagrant/docs/cloud-init/usage) for details
 * Support Disks, see [vagrant doc](https://developer.hashicorp.com/vagrant/docs/disks/usage) for details
+* Pin NUMA nodes, see [numactl repo](https://github.com/numactl/numactl)
 
 ## Usage
 
@@ -59,6 +60,23 @@ Prepare a `Vagrantfile`, see [Example](#example), and start:
 ```
 vagrant up --provider qemu
 ```
+
+### Installing numactl
+
+The `numactl_args` option is only available on Linux hosts and requires the `numactl` tool to be installed on your system.
+
+- **Debian/Ubuntu**:  
+  ```sh
+  sudo apt-get install numactl
+  ```
+- **RHEL/CentOS/Fedora**:  
+  ```sh
+  sudo dnf install numactl
+  ```
+- **Arch Linux**:  
+  ```sh
+  sudo pacman -S numactl
+  ```
 
 Notes:
 * may need password to setup SMB on Mac,
@@ -104,6 +122,9 @@ This provider exposes a few provider-specific configuration options:
   * `firmware_format` - The format of aarch64 firmware images (`edk2-aarch64-code.fd` and `edk2-arm-vars.fd`) loaded from `qemu_dir`, default: `raw`
   * `other_default` - The other default arguments used by this plugin, default: `%W(-parallel null -monitor none -display none -vga none)`
   * `extra_image_opts` - Options passed via `-o` to `qemu-img` when the base qcow2 images are created, default: `[]`
+  * `numactl_args` - Pin specific NUMA nodes using `numactl`. 
+    > Available on Linux hosts and requires the `numactl` tool to be installed on your system. 
+    > If `numactl` is not installed, QEMU startup will fail if you set this option.
 
 ### Usage
 
@@ -301,6 +322,19 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+
+12. **(Optional)**: Pin QEMU with numactl (Linux only)
+
+    In your `Vagrantfile`:
+    ```ruby
+    config.qemu.numactl_args = ['--cpunodebind=0', '--membind=0']
+    ```
+
+    This will prepend your specified arguments to the QEMU launch command, e.g.:
+
+    ```sh
+    numactl --cpunodebind=0 --membind=0 qemu-system-x86_64 ...
+    ```
 
 See the [QEMU Documentation](https://www.qemu.org/docs/master/devel/multiple-iothreads.html) and [heiko-sieger.info/tuning-vm-disk-performance/](https://www.heiko-sieger.info/tuning-vm-disk-performance/) for more details.
 

--- a/examples/numactl/README.md
+++ b/examples/numactl/README.md
@@ -1,0 +1,131 @@
+# Overview
+
+This directory contains the necessary files to set up and test a virtual machine using Vagrant with QEMU as the provider. The setup includes NUMA node configuration and custom QEMU settings. It assumes that you have followed the prerequistes detailed in the [primary documentation](../../README.md).
+
+## Contents
+
+- **get_numa_info.sh**: A script to gather NUMA information from the host system. This script outputs CPU-to-NUMA node mappings to a file, which is used by the Vagrantfile for VM configuration.
+
+- **qemu_config.yml**: A YAML configuration file containing paths and settings for the custom QEMU build. This file is read by the Vagrantfile to configure the QEMU provider.
+
+- **numactl-Vagrantfile**: The Vagrant configuration file that defines the VM setup for NUMA node bindings. It uses the `qemu` provider and custom settings specified in `qemu_config.yml`.
+
+## Setup Instructions
+
+You can change the default `generic/ubuntu2204` box for the VM in the [Vagrant Public Registry](https://portal.cloud.hashicorp.com/vagrant/discover?architectures=amd64&next=CgxXekk1TWpVM05WMD0%3D&providers=qemu).
+
+1. **Generate NUMA Information**:
+   Run the `get_numa_info.sh` script to gather NUMA information from the host. This will create a file `/tmp/numa_info.txt` with the necessary mappings.
+
+   ```bash
+   bash get_numa_info.sh
+   ```
+
+2. **Copy the files**: Copy the files `qemu_config.yml` and `numactl-Vagrantfile` to a temp directory.
+
+    ```bash
+    mkdir /tmp/test-qemu-numactl
+    cp ./qemu_config.yml /tmp/test-qemu-numactl
+    cp ./numactl-Vagrantfile /tmp/test-qemu-numactl/Vagrantfile
+    cd /tmp/test-qemu-numactl
+    ```
+
+3. **Configure QEMU Settings**: Ensure that `qemu_config.yml` is correctly configured with the paths to your custom QEMU build. The file should include entries like:
+
+   ```bash
+   custom_qemu_bin: "/path/to/custom/qemu/bin/qemu-system-x86_64"
+   custom_qemu_dir: "/path/to/custom/qemu"
+   ```
+
+3. **Run Vagrant**: Use Vagrant to bring up the virtual machine defined in the Vagrantfile. This will use the NUMA information and QEMU settings to configure the VM.
+
+   ```bash
+   vagrant up
+   ```
+
+   This command will start the VM with the specified configuration, including NUMA node bindings.
+
+4. **Log into the VM**: Connect to the VM and explore
+
+    ```bash
+    vagrant ssh
+    ```
+
+5. **Clean up**: Once you are finished running whatever experiments
+
+    ```bash
+    vagrant destroy -f
+    ```
+
+### Notes
+
+* Ensure that the `get_numa_info.sh` script is executable. You can set the executable permission with:
+
+    ```bash
+    chmod +x get_numa_info.sh
+    ```
+
+* Verify that the paths in `qemu_config.yml` are correct and accessible.
+* The Vagrantfile assumes that the NUMA information is stored in `/tmp/numa_info.txt`. Ensure this file is generated before running `vagrant up`.
+
+By following these instructions, you can set up and test the virtual machine with NUMA configuration using Vagrant and QEMU.
+
+## Exploration
+
+This section walks through an exploration of the enviornment to determine what has been launched and how to investigate various artifacts.
+
+1. Get the pid of the VM:
+
+    ```bash
+    cd $HOME
+    find . -type f -name *.pid
+    ./.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu.pid
+    cat ./.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu.pid
+    109245
+    ```
+
+2. Explore the NUMA node pinning:
+
+    ```bash
+    numactl --show --pid 109245
+    policy: default
+    preferred node: current
+    physcpubind: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95
+    cpubind: 0 1 2 3 4 5 6 7
+    nodebind: 0 1 2 3 4 5 6 7
+    membind: 0 1 2 3 4 5 6 7
+    preferred:
+    ```
+
+    > The `cpubind` and `nodebind` outputs indicate that the VM process is restricted to CPUs and memory from nodes 0-7.
+
+# Known Issues
+
+The `vagrant destroy` command does not properly clean up the `qemu` VM, [see #35](https://github.com/ppggff/vagrant-qemu/issues/35)
+
+* To clean up, view the full command using the `pid` of the VM:
+
+    ```bash
+    ps -p 109245 -o pid,ppid,user,start,cmd --width 1500 | cat
+    PID    PPID USER      STARTED CMD
+    109245       1 enpicket 14:48:49 /usr/bin/qemu-system-x86_64 -machine type=q35,accel=kvm -cpu host -smp 4 -m 12288 -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::50022-:22 -drive if=virtio,id=disk0,format=qcow2,file=/home/enpicket/git-repos/vagrant-qemu/examples/numactl/.vagrant/machines/numactl-test-vm/qemu/vq_vtlymSCoO-Q/linked-box.img -chardev socket,id=mon0,path=/home/enpicket/.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu_socket,server=on,wait=off -mon chardev=mon0,mode=readline -chardev socket,id=ser0,path=/home/enpicket/.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu_socket_serial,server=on,wait=off -serial chardev:ser0 -pidfile /home/enpicket/.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu.pid -daemonize -parallel null -monitor none -display none -vga none
+    ```
+
+    > Note in this case, the pid is `109245` also, note the socket `/home/enpicket/.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu_socket`
+
+    * Try connecting to the VM socket and issuing a shutdown:
+
+    ```bash
+    export VM_PID=109245 # REPLACE WITH YOUR VM's PID
+    export QEMU_SOCKET="/home/enpicket/.vagrant.d/tmp/vagrant-qemu/vq_vtlymSCoO-Q/qemu_socket"
+    # REPLACE THE ABOVE WITH THE PATH TO YOUR SOCKET
+    socat UNIX-CONNECT:$QEMU_SOCKET stdio
+    (qemu) system_powerdown
+    ```
+
+    * If this fails with the error: `No such file or directory`, issue a graceful shutdown:
+
+    ```bash
+    kill -15 $VM_PID
+    ```
+

--- a/examples/numactl/get_numa_info.sh
+++ b/examples/numactl/get_numa_info.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Gather NUMA information
+numactl --hardware | awk '/node [0-9]+ cpus:/ {node=$2; for (i=4; i<=NF; i++) print $i, node}' > /tmp/numa_info.txt

--- a/examples/numactl/numactl-Vagrantfile
+++ b/examples/numactl/numactl-Vagrantfile
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+require 'yaml'
+
+qemu_config_data = YAML.load_file('qemu_config.yml')
+
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Read NUMA information from the file
+  numa_info = File.read("/tmp/numa_info.txt").split("\n").map { |line| line.split }
+
+  # Create a hash to map CPUs to NUMA nodes
+  numactl_hardware = {}
+  numa_info.each do |cpu, node|
+    numactl_hardware[cpu.to_i] = node.to_i
+  end
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.box_version = "4.3.12"
+
+  config.vm.define "numactlvm" do |guest|
+    guest.vm.hostname = "numactlvm"
+
+    config.vm.provider "qemu" do |qe|
+        # Customize architecture
+        qe.arch = "x86_64"
+
+        # Machine Type
+        qe.machine = "type=q35,accel=kvm"
+
+        # Use custom qemu build
+        qe.qemu_bin = qemu_config_data['custom_qemu_bin']
+        qe.qemu_dir = qemu_config_data['custom_qemu_dir']
+
+        # CPU configuration
+        qe.cpu = "host"
+
+        # Generate SMP arguments using standard QEMU syntax
+        smp_args = 4  # Example: Set the number of CPUs
+        qe.smp = "#{smp_args}"
+        qe.cpus = smp_args
+
+        # Generate NUMA node bindings
+        numa_nodes = []
+        (0...smp_args).each do |cpu|
+          node = numactl_hardware[cpu]
+          unless numa_nodes.include?(node)
+            numa_nodes << node
+          end
+        end
+
+        # Generate numactl arguments
+        cpunodebind = numa_nodes.join(',')
+        membind = numa_nodes.join(',')
+        qe.numactl_args = ["--cpunodebind=#{cpunodebind}", "--membind=#{membind}"]
+
+        # Network and Drive Configuration
+        qe.net_device = "virtio-net-pci"  # Default, "virtio-net-device"
+    end
+    # Provisioning to set timezone (example)
+    guest.vm.provision "shell", inline: "timedatectl set-timezone America/Phoenix"
+  end
+end

--- a/examples/numactl/qemu_config.yml
+++ b/examples/numactl/qemu_config.yml
@@ -1,0 +1,2 @@
+custom_qemu_dir: "/usr/share/qemu"
+custom_qemu_bin: "/usr/bin/qemu-system-x86_64"

--- a/lib/vagrant-qemu/action/start_instance.rb
+++ b/lib/vagrant-qemu/action/start_instance.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
             :firmware_format => env[:machine].provider_config.firmware_format,
             :other_default => env[:machine].provider_config.other_default,
             :extra_image_opts => env[:machine].provider_config.extra_image_opts,
+            :numactl_args => env[:machine].provider_config.numactl_args,
           }
 
           env[:ui].output(I18n.t("vagrant_qemu.starting"))

--- a/lib/vagrant-qemu/config.rb
+++ b/lib/vagrant-qemu/config.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
       attr_accessor :firmware_format
       attr_accessor :other_default
       attr_accessor :extra_image_opts
+      attr_accessor :numactl_args
 
       def initialize
         @ssh_host = UNSET_VALUE
@@ -51,6 +52,7 @@ module VagrantPlugins
         @firmware_format = UNSET_VALUE
         @other_default = UNSET_VALUE
         @extra_image_opts = UNSET_VALUE
+        @numactl_args = UNSET_VALUE
       end
 
       #-------------------------------------------------------------------
@@ -86,6 +88,7 @@ module VagrantPlugins
         @firmware_format = "raw" if @firmware_format == UNSET_VALUE
         @other_default = %W(-parallel null -monitor none -display none -vga none) if @other_default == UNSET_VALUE
         @extra_image_opts = nil if @extra_image_opts == UNSET_VALUE
+        @numactl_args = nil if @numactl_args == UNSET_VALUE
 
         # TODO better error msg
         @ssh_port = Integer(@ssh_port)

--- a/lib/vagrant-qemu/driver.rb
+++ b/lib/vagrant-qemu/driver.rb
@@ -82,6 +82,17 @@ module VagrantPlugins
           end
 
           cmd = []
+
+          if options[:numactl_args] && !options[:numactl_args].nil? && !options[:numactl_args].empty?
+            unless Vagrant::Util::Platform.linux?
+              raise "The 'numactl_args' option is only supported on Linux hosts. Please remove it from your Vagrantfile or use this feature on a compatible system."
+            end
+            unless system('which numactl > /dev/null 2>&1')
+              raise "numactl is not installed on your system. Please install it using your distribution's package manager (e.g. 'sudo apt-get install numactl')."
+            end
+            cmd += ['numactl'] + Array(options[:numactl_args])
+          end
+
           if options[:qemu_bin].nil?
             cmd += %W(qemu-system-#{options[:arch]})
           else


### PR DESCRIPTION
This Pull Request enables the ability to pin NUMA nodes for the qemu process. The new `numactl_args` config option (Linux-only, validated in code):

* Updates to the QEMU launch logic to prepend `numactl` if configured and available.
* Friendly error messages if the host is not Linux or if `numactl` is not installed.
* Comprehensive README documentation, including install instructions and Linux-only warnings.